### PR TITLE
fix: Slider Dependecy Added

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,11 +43,13 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("androidx.activity:activity:1.8.0")
+    implementation("androidx.activity:activity-ktx:1.8.2")
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 
+    //Image Slider Library
+    implementation("com.github.denzcoskun:ImageSlideshow:0.1.2")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-
+        maven {
+            url = uri("https://www.jitpack.io" )
+        }
     }
 }
 


### PR DESCRIPTION
Added Image Slider Library :  https://github.com/denzcoskun/ImageSlideshow

fix:   Unexpected tokens (use ';' to separate expressions on the same line)
    maven {
            url 'https://jitpack.io'
        }

approach :- referred  [this article]( https://stackoverflow.com/questions/50389211/android-studio-maven-url-https-jitpack-io-cant-download)

